### PR TITLE
Restrict peer dependency version to latest working one

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@storybook/components": "^7.0.0",
     "@storybook/manager-api": "^7.0.0",
     "@storybook/types": "^7.0.0",
-    "launchdarkly-react-client-sdk": "^3.0.0",
+    "launchdarkly-react-client-sdk": ">=3.0.0 <3.0.7",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"
   }


### PR DESCRIPTION
Restrict `launchdarkly-react-client-sdk` to last working peer dependency until https://github.com/kodai3/storybook-addon-launchdarkly/issues/10 is fixed.

(It's working with `3.0.6` but not with `3.0.7` - thanks to launchdarkly for introducing a breaking change in a patch. 🙏)