### PR TITLE
chore: migrate @storybook/api to @storybook/manager-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "@storybook/api": "^7.0.0",
     "@storybook/components": "^7.0.0",
     "@storybook/manager-api": "^7.0.0",
     "@storybook/types": "^7.0.0",

--- a/src/panel.tsx
+++ b/src/panel.tsx
@@ -1,4 +1,4 @@
-import { useParameter } from '@storybook/api';
+import { useParameter } from '@storybook/manager-api';
 import { Link, Placeholder, ResetWrapper, Table } from '@storybook/components';
 import type { ReactSdkContext } from 'launchdarkly-react-client-sdk/lib/context';
 import { FC } from 'react';

--- a/src/title.ts
+++ b/src/title.ts
@@ -1,4 +1,4 @@
-import { useParameter } from '@storybook/api';
+import { useParameter } from '@storybook/manager-api';
 import type { ReactSdkContext } from 'launchdarkly-react-client-sdk/lib/context';
 import { PARAM_KEY } from './constants';
 


### PR DESCRIPTION
[@storybook/api](https://www.npmjs.com/package/@storybook/api) has been moved to @storybook/manager-api in Storybook v8.

@storybook/manager-api works in both v8 and v7!